### PR TITLE
lib: Support road vehicle properties

### DIFF
--- a/grf/lib.py
+++ b/grf/lib.py
@@ -173,11 +173,6 @@ class Callback:
             CARGO_AGE_PERIOD = 0x22
             SHORTEN_BY = 0x23
 
-        Properties = {
-            "Train": TrainProperties,
-            "RoadVehicle": RoadVehicleProperties,
-            }
-
     class Station:
         AVAILABILITY = 0x13
         SPRITE_LAYOUT = 0x14
@@ -291,7 +286,7 @@ class CallbackManager:
 
             self._callbacks[prop_id] = value
 
-    def __init__(self, domain, callbacks=None, subdomain="Train"):
+    def __init__(self, domain, callbacks=None, properties=None):
         self._domain = domain
         self._callbacks = {}
         self.graphics = None
@@ -301,7 +296,7 @@ class CallbackManager:
         for k, v in callbacks.items():
             if v is not None:
                 setattr(self, k, v)
-        self.properties = self.Properties(self._domain.Properties[subdomain], prop_cb)
+        self.properties = self.Properties(properties, prop_cb)
 
     def __setattr__(self, name, value):
         if name.startswith('_') or name in ('graphics', 'purchase_graphics', 'properties'):
@@ -482,9 +477,9 @@ class Vehicle(grf.SpriteGenerator):
         SYNC_VARIANT_EXCLUSIVE_PREVIEW = 0x04
         SYNC_VARIANT_RELIABILITY = 0x08
 
-    def __init__(self, feature, callbacks, purchase_sprite=None, subdomain="Train"):
+    def __init__(self, feature, callbacks, purchase_sprite=None, properties=Callback.Vehicle.TrainProperties):
         self.feature = feature
-        self.callbacks = CallbackManager(Callback.Vehicle, callbacks, subdomain=subdomain)
+        self.callbacks = CallbackManager(Callback.Vehicle, callbacks, properties=properties)
         self.purchase_sprite = purchase_sprite
 
     def _gen_name_sprites(self, vehicle_id):
@@ -542,7 +537,7 @@ class RoadVehicle(Vehicle):
         return RoadVehicle.Speed((speed * 16 + 4) // 5)
 
     def __init__(self, *, id, name, max_speed, length=None, liveries=None, additional_text=None, livery_refits=None, callbacks=None, purchase_sprite=None, **props):
-        super().__init__(grf.RV, callbacks, purchase_sprite=purchase_sprite, subdomain="RoadVehicle")
+        super().__init__(grf.RV, callbacks, purchase_sprite=purchase_sprite, properties=Callback.Vehicle.RoadVehicleProperties)
         for l in liveries or []:
             if 'name' not in l:
                 raise ValueError(f'RoadVehicle livery is missing the name')
@@ -683,7 +678,7 @@ class Train(Vehicle):
         return effect | position | wagon_power * 0x7f
 
     def __init__(self, *, id, name, max_speed, weight, length=None, liveries=None, additional_text=None, sound_effects=None, callbacks=None, purchase_sprite=None, **props):
-        super().__init__(grf.TRAIN, callbacks, purchase_sprite=purchase_sprite, subdomain="RoadVehicle")
+        super().__init__(grf.TRAIN, callbacks, purchase_sprite=purchase_sprite, properties=Callback.Vehicle.TrainProperties)
 
         for l in liveries or []:
             if 'name' not in l:

--- a/grf/lib.py
+++ b/grf/lib.py
@@ -608,7 +608,7 @@ class RoadVehicle(Vehicle):
         res.extend(self._set_callbacks(g))
 
         # Liveries
-        if len(self.liveries) > 1:
+        if self.liveries and len(self.liveries) > 1:
             self.callbacks.cargo_subtype = grf.Switch(
                 ranges={i: g.strings.add(l['name']).get_global_id() for i, l in enumerate(self.liveries)},
                 default=0x400,

--- a/tests/test_lib_rv_properties_cb.py
+++ b/tests/test_lib_rv_properties_cb.py
@@ -1,0 +1,133 @@
+from grf import RoadVehicle, RV, Ref, DefineStrings, Define, Action3, Switch
+
+from .common import check_lib
+
+
+def test_lib_rv_basics():
+	check_lib(
+		None,
+		RoadVehicle(
+			id=0x1D1D,
+			name='Test RV',
+			max_speed=0xEE,
+			weight=0xE1,
+			callbacks={
+				'graphics': 0xE0,
+			}
+		),
+		[
+	        DefineStrings(
+	            feature=RV,
+	            lang=127,
+	            offset=7453,
+	            is_generic_offset=False,
+	            strings=[b'Test RV']
+	        ),
+	        Define(
+	            feature=RV,
+	            id=0x1D1D,
+	            props={
+	                'sprite_id': 255,
+	                'precise_max_speed': 255,
+	                'max_speed': 0xEE,
+	                'weight': 225,
+	            }
+	        ),
+	        Action3(
+	            feature=RV,
+	            wagon_override=False,
+	            ids=[0x1D1D],
+	            maps={},
+	            default=0xE0,
+	        )
+
+		]
+	)
+
+
+def test_lib_rv_properties_cb():
+	check_lib(
+		None,
+		RoadVehicle(
+			id=0x1D1D,
+			name='Test RV',
+			max_speed=0xEE,
+			weight=0xE1,
+			callbacks={
+				'graphics': 0xE0,
+				'properties': {
+					'loading_speed': 0x10AD,
+					'running_cost_factor': 0x10A0,
+					'cargo_capacity': 0xCAA1,
+					'cost_factor': 0xC057,
+					'power': 0x50E2,
+					'weight': 0xE167,
+					'max_speed': 0xAEED,
+					'tractive_effort_coefficient': 0xEEC0,
+					'cargo_age_period': 0xCAAE,
+					'shorten_by': 0x5027,
+				}
+			}
+		),
+		[
+	        DefineStrings(
+	            feature=RV,
+	            lang=127,
+	            offset=7453,
+	            is_generic_offset=False,
+	            strings=[b'Test RV']
+	        ),
+	        Define(
+	            feature=RV,
+	            id=0x1D1D,
+	            props={
+	                'sprite_id': 255,
+	                'precise_max_speed': 255,
+	                'max_speed': 0xEE,
+	                'weight': 225,
+	            }
+	        ),
+	        Switch(
+	            feature=RV,
+	            ref_id=254,
+	            related_scope=False,
+	            code='extra_callback_info1_byte',
+	            ranges={
+	                0x07: 0x10AD,
+	                0x09: 0x10A0,
+	                0x0F: 0xCAA1,
+	                0x11: 0xC057,
+	                0x13: 0x50E2,
+	                0x14: 0xE167,
+	                0x15: 0xAEED,
+	                0x18: 0xEEC0,
+	                0x22: 0xCAAE,
+	                0x23: 0x5027,
+	            },
+	            default=224,
+	        ),
+	        Switch(
+	            feature=RV,
+	            ref_id=255,
+	            related_scope=False,
+	            code='current_callback',
+	            ranges={54: Ref(254)},
+	            default=224,
+	        ),
+	        Switch(
+	            feature=RV,
+	            ref_id=253,
+	            related_scope=False,
+	            code='current_callback',
+	            ranges={54: Ref(254)},
+	            default=224,
+	        ),
+	        Action3(
+	            feature=RV,
+	            wagon_override=False,
+	            ids=[0x1D1D],
+	            maps={255: Ref(255)},
+	            default=Ref(253),
+	        )
+		]
+	)


### PR DESCRIPTION
Use subdomains to find the right property mapping for each vehicle type (only train and RV supported right now).

Vehicles defaulting to the train list for backwards compatibility (but probably unnecessary)