### PR TITLE
Refer to `NewGRF.BLITTER_BPP_8` instead of `BLITTER_BPP_8`

### DIFF
--- a/grf/grf.py
+++ b/grf/grf.py
@@ -727,7 +727,7 @@ class NewGRF(BaseNewGRF):
         }
 
         if preferred_blitter is not None:
-            if preferred_blitter not in (BLITTER_BPP_8, BLITTER_BPP_32):
+            if preferred_blitter not in (NewGRF.BLITTER_BPP_8, NewGRF.BLITTER_BPP_32):
                 raise ValueError(f'Invalid value for preferred_blitter: {preferred_blitter}')
             props['INFO']['BLTR'] = preferred_blitter
 


### PR DESCRIPTION
Seems we need to refer to `NewGRF.BLITTER_BPP_{8,32}` even inside the class itself. Fixes e5432b7ae00e76ba99c60a11ce5cf67abb6cf9d6.