### PR TITLE
Add support for compiling & decompiling the "layout" property

### DIFF
--- a/grf/actions.py
+++ b/grf/actions.py
@@ -1194,6 +1194,8 @@ class DefineMultiple(LazyAction):
                 for tile_info in layout:
                     if isinstance(tile_info['gfx'], NewIndustryTileID):
                         res = res + struct.pack('<BBBH', tile_info['xofs'], tile_info['yofs'], 0xfe, tile_info['gfx'].tile_id)
+                    elif isinstance(tile_info['gfx'], OldIndustryTileID):
+                        res = res + struct.pack('<BBB', tile_info['xofs'], tile_info['yofs'], tile_info['gfx'].tile_id)
                     elif tile_info['gfx'] is None:
                         res = res + struct.pack('<BBB', tile_info['xofs'], tile_info['yofs'], 0xff)
                     else:

--- a/grf/decompile.py
+++ b/grf/decompile.py
@@ -215,6 +215,7 @@ def read_property(name, data, ofs, fmt):
         size = d.get_dword()
         res = []
         for _ in range(num):
+            layout = []
             for k in range(size):  # effectively infinite loop
                 xofs = d.get_byte()
                 yofs = d.get_byte()
@@ -234,11 +235,12 @@ def read_property(name, data, ofs, fmt):
                     yofs = utoi8(yofs & 0xff)
                     gfx = None
 
-                res.append({
+                layout.append({
                     'xofs': xofs,
                     'yofs': yofs,
                     'gfx': gfx,
                 })
+            res.append(layout)
 
         return res, d.offset
 

--- a/grf/decompile.py
+++ b/grf/decompile.py
@@ -229,7 +229,7 @@ def read_property(name, data, ofs, fmt):
                 gfx = d.get_byte()
                 if gfx == 0xfe:
                     local_tile_id = d.get_word()
-                    gfx = f'todo_ref({local_tile_id})'
+                    gfx = grf.NewIndustryTileID(local_tile_id)
                 elif gfx == 0xff:
                     xofs = utoi8(xofs & 0xff)
                     yofs = utoi8(yofs & 0xff)

--- a/grf/decompile.py
+++ b/grf/decompile.py
@@ -234,6 +234,8 @@ def read_property(name, data, ofs, fmt):
                     xofs = utoi8(xofs & 0xff)
                     yofs = utoi8(yofs & 0xff)
                     gfx = None
+                else:
+                    gfx = grf.OldIndustryTileID(gfx)
 
                 layout.append({
                     'xofs': xofs,

--- a/grf/grf.py
+++ b/grf/grf.py
@@ -17,7 +17,8 @@ from .actions import Ref, CB, Range, ReferenceableAction, ReferencingAction, get
                      BasicSpriteLayout, AdvancedSpriteLayout, ExtendedSpriteLayout, Switch, \
                      IndustryProductionCallback, Action3, Map, DefineStrings, ReplaceNewSprites, \
                      ModifySprites, If, SetDescription, ReplaceOldSprites, ErrorMessage, Comment, \
-                     ComputeParameters, Label, SoundEffects, ImportSound, Translations, SetProperties, LazyAction
+                     ComputeParameters, Label, SoundEffects, ImportSound, Translations, SetProperties, LazyAction, \
+                     OldIndustryTileID, NewIndustryTileID
 from .parser import Node, Expr, Value, Var, Temp, Perm, Call, parse_code, OP_INIT, SPRITE_FLAGS, GenericVar
 from .common import Feature, hex_str, utoi32, FeatureMeta, to_bytes, GLOBAL_VAR
 from .common import PALETTE


### PR DESCRIPTION
Hi,

I am trying to add industry layouts, and the first step was to decompile FIRS for studying, and apparently the existing decompilation flattened the list of list into a list.

I'll add more stuff about industry layouts in this branch if I have time, but I think this bug fix itself is also pretty clear.