### PR TITLE
setup.py: use exclude instead of include.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     },
     description='Framework for making OpenTTD NewGRF files',
     author='dP',
-    packages=find_packages(include=['grf']),
+    packages=find_packages(exclude=['tests']),
     entry_points={
         'console_scripts': [
             'grftopy = grf.decompile:main',


### PR DESCRIPTION
This makes the built wheel to contain needed python files under `grf/lib` correctly.

See also #18, which is an alternative.