### PR TITLE
setup.py: use glob to include submodules.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     },
     description='Framework for making OpenTTD NewGRF files',
     author='dP',
-    packages=find_packages(include=['grf']),
+    packages=find_packages(include=['grf', 'grf.*']),
     entry_points={
         'console_scripts': [
             'grftopy = grf.decompile:main',


### PR DESCRIPTION
I think I understand `setup(includes=blablabla)` now: it searches for all python modules under the current directory, represent each as a python module name (e.g. `grf.lib`).

Then, each of the supplied glob in `includes` is used to match the said module names, and anything that matches is included in the wheel. So, to match both `grf` and `grf.lib`, a single `grf*` suffices, but it also risks accidentally including stuff like `grf_resources`. On the other hand, using both `grf` and `grf.*` makes sure to exclude any other top-level directories while still being future-proof enough to include anything under `grf/` recursively.

See also #17, which is an alternative.