### PR TITLE
(fix) Set bpp for WithMask

### DIFF
--- a/grf/sprites.py
+++ b/grf/sprites.py
@@ -588,7 +588,7 @@ class WithMask(Sprite):
             xofs=self.sprite.xofs,
             yofs=self.sprite.yofs,
             zoom=self.sprite.zoom,
-            bpp=None,
+            bpp=self.sprite.bpp,
             crop=self.sprite.crop and self.mask.crop,
             name=name,
         )


### PR DESCRIPTION
The current implementation breaks `AlternativeSprites.get_sprite()`.

I am not sure if simply copying the `bpp` is the best design, but seeing that the mask is always 8bpp and is not what we usually refer to as the actual sprite bpp, I feel this might be justified?

Anyways, I feel I’m more like asking a question than proposing a change, but this PR is what I came up with.