### PR TITLE
(action0) add new properties for station

### DIFF
--- a/docs/entity_properties.md
+++ b/docs/entity_properties.md
@@ -189,6 +189,8 @@ https://newgrf-specs.tt-wiki.net/wiki/Action0/Stations
 | 0x19 | road_routing | Not supported | Road routing (reserved for future use) |
 | 0x1A | advanced_layout | NewStationLayoutProperty | Advanced sprite layout with register modifiers |
 | 0x1B | min_bridge_height | 8 bytes (TODO) | dvanced sprite layout with register modifiers |
+| 0x1C | station_name | int(0-65535) | Station name ID |
+| 0x1D | station_class_name | int(0-65535) | Station class name ID |
 
 
 # Canals (CANAL, 0x05)

--- a/grf/actions.py
+++ b/grf/actions.py
@@ -730,6 +730,8 @@ ACTION0_STATION_PROPS = {
     0x19: ('road_routing', 'V'),  # Road routing (reserved for future use)
     0x1A: ('advanced_layout', NewStationLayoutProperty()),  # Advanced sprite layout with register modifiers
     0x1B: ('min_bridge_height', '8*B'),  # Advanced sprite layout with register modifiers
+    0x1C: ('station_name', 'W'),  # Station name
+    0x1D: ('station_class_name', 'W'),  # Station class name
 }
 
 # TODO river


### PR DESCRIPTION
Add the two new properties introduced in [this commit](https://github.com/OpenTTD/OpenTTD/commit/bc7dfd7b46c0184dc4b2cc376556702ac0ac1019). I also updated the GRFSpec wiki to include these properties.

Tested with the station mod contained within https://github.com/ahyangyi/openttd-newgrfs/tree/station/name-manager. If the branch no longer exists it's probably already merged into `main` :P