### PR TITLE
(actions) support long (>=0xff) station ids

### DIFF
--- a/grf/actions.py
+++ b/grf/actions.py
@@ -1921,7 +1921,7 @@ class Action3(Action, ReferencingAction):
         else:
             idlist = self.ids
             idfmt = 'B'
-            if self.feature in VEHICLE_FEATURES and any(x >= 0xff for x in self.ids):
+            if (self.feature in VEHICLE_FEATURES or self.feature == STATION) and any(x >= 0xff for x in self.ids):
                 idlist = [0xff] * (2 * idcount)
                 idlist[1::2] = self.ids
                 idfmt = 'BH'


### PR DESCRIPTION
Station IDs can be larger than 0xff and can use the extended format as well now.

Someday we might need a `LONG_ID_FEATURES` instead of `VEHICLE_FEATURES` to do this kind of test. However, I grepped the current occurrences of `VEHICLE_FEATURES` and apparently this is the only place where we need `LONG_ID_FEATURES`. The other places involving `VEHICLE_FEATURES` are about strings, where stations use action 0 strings or C4xx/C5xx instead.

So, considering that it is the only occurrence I find a need to modify, I’m being conservative and just add the clause I need at this moment.