### PR TITLE
Allow argparse to be used in the generate.py

### DIFF
--- a/grf/utils.py
+++ b/grf/utils.py
@@ -231,7 +231,7 @@ def main(g, grf_file, commands=None):
             c['add_args'](cmd_parser)
         cmd_parser.set_defaults(func=c['handler'])
 
-    args = parser.parse_args()
+    args, unknown = parser.parse_known_args()
 
     if args.command is None:
         build_func(g, grf_file, None)


### PR DESCRIPTION
Currently a project using grf-py can't use argparse on it's own without getting errors due to grf-py not recognising the options. this pr solves that byusing parse_known_args instead of parse_args which would throw an error