### PR TITLE
Add: support for custom language tags

### DIFF
--- a/grf/strings.py
+++ b/grf/strings.py
@@ -286,7 +286,8 @@ class StringManager:
         self._persistents[ref.hash] = (string_id, ref)
         return string_id
 
-    def import_lang_dir(self, lang_dir, default_lang_file='english.lng'):
+    def import_lang_dir(self, lang_dir, default_lang_file='english.lng', custom_tags_file="custom_tags.txt"):
+        grfstrings.read_extra_commands(custom_tags_file)
         grfstrings.langs = []
         grfstrings.default_lang = grfstrings.Language(True)
         grfstrings.default_lang.langid = grfstrings.DEFAULT_LANGUAGE


### PR DESCRIPTION
Just a quick fix for something that was bothering me. grf-py now reads from custom_tags.txt when importing a language file, thus allowing files from NML to be reused without any modification.