### PR TITLE
Support special variable access in Action D

### DIFF
--- a/grf/actions.py
+++ b/grf/actions.py
@@ -2268,6 +2268,10 @@ ActionC = Comment
 class ComputeParameters(Action):
     def __init__(self, *, target, operation, if_undefined, source1, source2, value=None):
             super().__init__()
+
+            if source2 == 0xfe:
+                assert operation == 0x00 and not if_undefined, "Only assignment is accepted for special variable access"
+
             self.target = target
             self.operation = operation
             self.if_undefined = if_undefined
@@ -2278,7 +2282,7 @@ class ComputeParameters(Action):
     def get_data(self, context):
         operation_byte = self.operation | 0x80 * self.if_undefined
         res = bytes((0x0D, self.target, operation_byte, self.source1, self.source2))
-        if self.source1 == 0xff or self.source2 == 0xff:
+        if self.source1 == 0xff or self.source2 == 0xff or self.source2 == 0xfe:
             if isinstance(self.value, bytes):
                 res += self.value
             else:


### PR DESCRIPTION
This pull request implements the "special variable access" mode of Action D, detailed in the documentation here:

https://newgrf-specs.tt-wiki.net/wiki/ActionD#target.2C_source1.2C_source2

As a use case, I am using this to read the spriteID of the built-in 2cc remaps:

https://github.com/OpenTTD-China-Set/China-Set-Stations-Wuhu/blob/ccdc918b672ad07cbf64cf5bb4136d0a6fd975da/station/dovemere_gen.py#L40