### PR TITLE
Fix: in newer versions of numpy, multiplying an int and an uint8 raises an exception

### DIFF
--- a/grf/colour.py
+++ b/grf/colour.py
@@ -259,7 +259,7 @@ def openttd_adjust_brightness(c, brightness):
 
     r, g, b = c
     combined = (r << 32) | (g << 16) | b
-    combined *= brightness
+    combined *= int(brightness)
 
     r = (combined >> 39) & 0x1ff
     g = (combined >> 23) & 0x1ff


### PR DESCRIPTION
This fixes it by... casting the uint8 to int.

I don't think the default behavior makes any sense TBH.